### PR TITLE
replace mentions of futurelearn by edX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Fortran MOOC
 
 This repository contains material for the PRACE MOOC on "Fortran for scientific
-programming".  The MOOC is hosted by FutureLearn
-(https://www.futurelearn.com/courses/fortran-for-scientific-computing).
+programming".  The MOOC is hosted by edX
+(https://learning.edx.org/course/course-v1:KULeuvenX+FORTRANx+3T2025/home).
 
 
 ## Content


### PR DESCRIPTION
## Summary by Sourcery

Update README to reference edX instead of FutureLearn

Documentation:
- Replace references to FutureLearn with edX in the course description
- Update course URL to point to the edX platform